### PR TITLE
Bugfix and proposition of transfer of ownership

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -7,7 +7,7 @@ zabbix.getApiVersion(function (err, resp, body) {
     console.log("Unauthenticated API version request, and the version is: " + body.result)
   }
 });
-zabbix.authenticate(function (err, resp, body) {
+zabbix.login(function (err, resp, body) {
   if (!err) {
     console.log("Authenticated! AuthID is: " + zabbix.authid);
   }

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -14,6 +14,12 @@ var Client = function (url, user, password) {
 Client.prototype.errors = E;
 
 Client.prototype.call = function call(method, params, callback) {
+  if(!callback) {
+    callback = params;
+    params = method.params;
+    method = method.method;
+  }
+
   var log = this.debug ? console.log.bind(console, '::zabbix['+(this.rpcid + 1)+']') : (function(){});
 
   log('method: ', method, ' params: ', JSON.stringify(params));

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -1,5 +1,6 @@
 var request = require('request');
 var E = require('./errors');
+var async = require('async');
 
 var Client = function (url, user, password) {
   this.url = url;
@@ -107,7 +108,7 @@ Client.prototype.login = function login(callback) {
 };
 
 //Version 2.4 uses the method user.logout
-Client.prototype.logout = function login(callback) {
+Client.prototype.logout = function logout(callback) {
     this.rpcid = 0; // Reset this, why not?
     this.call('user.logout', {}, function (error, response, body) {
 	if (!error) {
@@ -117,5 +118,34 @@ Client.prototype.logout = function login(callback) {
     }.bind(this)
 	     );
 };
+
+Client.prototype.safeCall = function safeCall(method, params, callback) {
+    this.rpcid = 0;
+    async.series({
+	login : function(callback) {
+	    this.login(function(err, resp, body) {
+		if(err) {
+		    return callback(err);	
+		};
+		callback();
+	    });
+	},
+	call : function(callback) {
+	    this.call(method, params, callback);
+	},
+	logout : function(callback) {
+	    this.logout(function(err, resp, body) {
+		if(err) {
+		    log.error("Error trying to logout from Zabbix Server");
+		    return callback(err);	
+		};
+		callback();
+	    });
+	}
+    }, function (err, results) {
+	if(err) return callback(err);
+	callback();
+    });
+}; 
 
 module.exports = Client;

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -100,6 +100,7 @@ Client.prototype.authenticate = function authenticate(callback) {
 //Version 2.4 uses the method user.login for authentication
 Client.prototype.login = function login(callback) {
   this.rpcid = 0; // Reset this, why not?
+  this.authid = null;  //Reset the authid because the login call should not have it
   this.call('user.login', {
       'user': this.user,
       'password' : this.password

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -106,5 +106,13 @@ Client.prototype.login = function login(callback) {
   );
 };
 
+//Version 2.4 uses the method user.logout
+Client.prototype.logout = function login(callback) {
+  this.rpcid = 0; // Reset this, why not?
+  this.call('user.logout', {}, function (error, response, body) {
+      callback(error, response, body);
+    }.bind(this)
+  );
+};
 
 module.exports = Client;

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -111,7 +111,7 @@ Client.prototype.logout = function login(callback) {
     this.rpcid = 0; // Reset this, why not?
     this.call('user.logout', {}, function (error, response, body) {
 	if (!error) {
-	    this.authid = "";
+	    this.authid = null;
 	}
 	callback(error, response, body);
     }.bind(this)

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -74,6 +74,7 @@ Client.prototype.getApiVersion = function getApiVersion(callback) {
   }.bind(this));
 };
 
+//Since the version 2.0 this method is a deprecated alias of user.login
 Client.prototype.authenticate = function authenticate(callback) {
   this.rpcid = 0; // Reset this, why not?
   this.call('user.authenticate', {
@@ -88,5 +89,22 @@ Client.prototype.authenticate = function authenticate(callback) {
     }.bind(this)
   );
 };
+
+//Version 2.4 uses the method user.login for authentication
+Client.prototype.login = function login(callback) {
+  this.rpcid = 0; // Reset this, why not?
+  this.call('user.login', {
+      'user': this.user,
+      'password' : this.password
+    }, function (error, response, body) {
+      if (!error) {
+        this.authid = body.result;
+      }
+
+      callback(error, response, body);
+    }.bind(this)
+  );
+};
+
 
 module.exports = Client;

--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -97,22 +97,25 @@ Client.prototype.login = function login(callback) {
       'user': this.user,
       'password' : this.password
     }, function (error, response, body) {
-      if (!error) {
-        this.authid = body.result;
-      }
-
-      callback(error, response, body);
+	if (!error) {
+            this.authid = body.result;
+	}
+	
+	callback(error, response, body);
     }.bind(this)
-  );
+	   );
 };
 
 //Version 2.4 uses the method user.logout
 Client.prototype.logout = function login(callback) {
-  this.rpcid = 0; // Reset this, why not?
-  this.call('user.logout', {}, function (error, response, body) {
-      callback(error, response, body);
+    this.rpcid = 0; // Reset this, why not?
+    this.call('user.logout', {}, function (error, response, body) {
+	if (!error) {
+	    this.authid = "";
+	}
+	callback(error, response, body);
     }.bind(this)
-  );
+	     );
 };
 
 module.exports = Client;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git://github.com/flexd/zabbix.js.git"
   },
   "dependencies": {
+    "async": "^1.4.2",
     "request": "~2.9.203"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi @flexd!

I'm a colleague of @joaobentes in the PAWMint lab. I have seen that you updated your wiki to deprecate your `zabbix.js` repo and forward people to his. He's just transferred ownership of his to our lab under `pawmint`. I would like to suggest to make a proper transfer of ownership of the repo so that your users are automatically forwarded to the new repo by github. What do you think?

If you are keen, you can simply accept this PR and then go to settings to transfer ownership to me first (@tibotiber), then I'll transfer it to our organisation account. This is because you cannot transfer directly to our account as you are not an account admin. Let me know first so that I clear the name as we are currently hosting our fork on it.

Just to let you know what we want to do with the repo: we are not planning much work on it but we would like to keep up with changes to the zabbix API or bug reports. We are going to leave it public, obviously and are keen to transfer out the ownership to anyone who would like to extend the development of the module (you in the future maybe, or anyone actually).

Let us know what you think of this. 

Best,

Thibaut for PAWMint.
